### PR TITLE
chore(Dockerfile): pin setuptools<70 to keep pkg_resources available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN set ex \
 		" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps tini \
-    && pip3 install -U --no-cache-dir wheel setuptools pip \
+    && pip3 install -U --no-cache-dir wheel "setuptools<70" pip \
     && pip3 install --no-cache-dir --user -r requirements.txt \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Unblocks Docker image builds. Same fix iotex-transaction-service got 2026-05-12 (PR #13 in that repo).

## Why

This repo's image hadn't been rebuilt since 2024-08-30. When PR #7 (add `:sha-<short>` tag to `build_image.yml`) merged today and triggered the first rebuild, the build died:

```
ModuleNotFoundError: No module named 'pkg_resources'
  File ".../drf_yasg/__init__.py", line 2, in <module>
    from pkg_resources import DistributionNotFound, get_distribution
```

setuptools 70.0.0 (released 2024-05-29) [removed `pkg_resources`](https://github.com/pypa/setuptools/issues/4128). Old Python deps (drf_yasg, gunicorn 20.x, others) still import it. The 2024-08-30 build worked because setuptools was <70 then; today's build pulls the current latest.

## Fix

One-line change in `Dockerfile`:

```diff
-    && pip3 install -U --no-cache-dir wheel setuptools pip \
+    && pip3 install -U --no-cache-dir wheel "setuptools<70" pip \
```

## Test plan

- [ ] After merge, push to `iotex-stg` triggers `build_image.yml`. Confirm both `:iotex-stg` and `:sha-<short>` tags published to GHCR for `safe-config-{web,nginx}`.
- [ ] iotex-web-ops staging-deploy PR (pending) bumps to the new SHA pin.

## Long-term

The proper fix is to update the Django dep stack so `pkg_resources` isn't used (`drf_yasg` → `drf-spectacular`, or wait for upstream `gnosis.*` → `safe_eth.*` rewrite). This pin is a tactical hold until that work happens.